### PR TITLE
move overview and table keys; remove navbar

### DIFF
--- a/BestPractices.Rmd
+++ b/BestPractices.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Best Practices Courses"
+title: " "
 subtitle: " "
 output: html_document
 ---
@@ -11,10 +11,6 @@ output: html_document
 }
 </style>
 
-### **Overview**
-
-The following table contains a list of Informatics Technology for Cancer Research (ITCR) program funded Best Practices courses from the ITCR Training Network (ITN). Completion through Leanpub (<img src=resources/images/leanpublogo.png height="20"> </img>) or Coursera (<img src=resources/images/courseralogo.png height="20"> </img>) will award certification in the course.  
-
 ```{r,echo=FALSE,results='hide',message=FALSE, warning=FALSE}
 library(DT)
 library(here)
@@ -25,12 +21,6 @@ library(magrittr)
 source("scripts/format-tables.R")
 ```
 
-**Table keys:**
-<div title="Table keys">
-<img src="resources/images/ITCRLogo.png" height="20"> </img> = ITCR Funded, <img src=resources/images/fhlogo.png height="20"></img> = Fred Hutch Cancer Center Funded<br></br>
-<img src=resources/images/bookstack.png height="20"> </img> = Bookdown, <img src=resources/images/courseralogo.png height="20"> </img> = Coursera,<img src=resources/images/leanpublogo.png height="20"> </img> = Leanpub, <img src="resources/images/githublogo.png"  height="20"> </img> = GitHub Source Material<br></br> 
-<img src="resources/images/keyboard-1405.png" height="20"> </img> = Software Developers, <img src="resources/images/hatching_chick_newlearner.png" height="35"> </img> = New to Data Science, <img src="resources/images/leaders.png" height = "35"> </img> = Leaders<br></br>
-</div>
 
 ```{r,echo=FALSE,results='hide',message=FALSE, warning=FALSE}
 # read in the google sheet

--- a/FutureCourses.Rmd
+++ b/FutureCourses.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Future Courses (All Categories)"
+title: " "
 subtitle: " "
 output: html_document
 ---
@@ -11,9 +11,6 @@ output: html_document
 }
 </style>
 
-### **Overview**
-
-The following table contains a list of Informatics Technology for Cancer Research (ITCR) program funded courses from the ITCR Training Network (ITN) currently or soon to be in development.
 
 ```{r,echo=FALSE,results='hide',message=FALSE, warning=FALSE}
 library(DT)
@@ -24,13 +21,6 @@ library(magrittr)
 
 source("scripts/format-tables.R")
 ```
-
-**Table keys:**
-<div title="Table keys">
-<img src="resources/images/ITCRLogo.png" height="20"> </img> = ITCR Funded, <img src=resources/images/fhlogo.png height="20"></img> = Fred Hutch Cancer Center Funded<br></br>
-<img src=resources/images/underconstruction.png height="20"></img> = Under Construction<br><br/>
-<img src="resources/images/keyboard-1405.png" height="20"> </img> = Software Developers, <img src="resources/images/hatching_chick_newlearner.png" height="35"> </img> = New to Data Science, <img src="resources/images/leaders.png" height = "35"> </img> = Leaders<br></br>
-</div>
 
 
 ```{r,echo=FALSE,results='hide',message=FALSE, warning=FALSE}

--- a/SoftwareDevelopment.Rmd
+++ b/SoftwareDevelopment.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Software Development Courses"
+title: " "
 subtitle: " "
 output: html_document
 ---
@@ -11,10 +11,7 @@ output: html_document
 }
 </style>
 
-### **Overview**
-
-The following table contains a list of Informatics Technology for Cancer Research (ITCR) program funded Software Development courses from the ITCR Training Network (ITN). Completion through Leanpub (<img src=resources/images/leanpublogo.png height="20"> </img>) or Coursera (<img src=resources/images/courseralogo.png height="20"> </img>) will award certification in the course. 
-
+ 
 ```{r,echo=FALSE,results='hide',message=FALSE, warning=FALSE}
 library(DT)
 library(here)
@@ -25,12 +22,6 @@ library(magrittr)
 source("scripts/format-tables.R")
 ```
 
-**Table keys:**
-<div title="Table keys">
-<img src="resources/images/ITCRLogo.png" height="20"> </img> = ITCR Funded, <img src=resources/images/fhlogo.png height="20"></img> = Fred Hutch Cancer Center Funded<br></br>
-<img src=resources/images/bookstack.png height="20"> </img> = Bookdown, <img src=resources/images/courseralogo.png height="20"> </img> = Coursera,<img src=resources/images/leanpublogo.png height="20"> </img> = Leanpub, <img src="resources/images/githublogo.png"  height="20"> </img> = GitHub Source Material<br></br> 
-<img src="resources/images/keyboard-1405.png" height="20"> </img> = Software Developers, <img src="resources/images/hatching_chick_newlearner.png" height="35"> </img> = New to Data Science, <img src="resources/images/leaders.png" height = "35"> </img> = Leaders<br></br>
-</div>
 
 ```{r,echo=FALSE,results='hide',message=FALSE, warning=FALSE}
 # read in the google sheet

--- a/TableKeys.Rmd
+++ b/TableKeys.Rmd
@@ -1,0 +1,26 @@
+---
+title: "TableKeys"
+author: "Kate Isaac"
+date: "`r Sys.Date()`"
+output: html_document
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+### **Overview of tables**
+
+The following tables contains a list of Informatics Technology for Cancer Research (ITCR) program funded courses from the ITCR Training Network (ITN). 
+
+These tables include courses categorized among three broad topics: <b>Best Practices</b> in informatics, <b>Informatic Fundamentals, Tools, and Resources</b>, and <b>Scientific Software Development</b>. A fourth table is included that lists future courses across all three topics.  
+
+Completion through Leanpub (<img src=resources/images/leanpublogo.png height="20"> </img>) or Coursera (<img src=resources/images/courseralogo.png height="20"> </img>) will award certification for a course.
+
+**Table keys:**
+<div title="Table keys">
+<img src="resources/images/ITCRLogo.png" height="20"> </img> = ITCR Funded, <img src=resources/images/fhlogo.png height="20"></img> = Fred Hutch Cancer Center Funded<br></br>
+<img src=resources/images/bookstack.png height="20"> </img> = Bookdown, <img src=resources/images/courseralogo.png height="20"> </img> = Coursera,<img src=resources/images/leanpublogo.png height="20"> </img> = Leanpub, <img src="resources/images/githublogo.png"  height="20"> </img> = GitHub Source Material<br></br>
+<img src=resources/images/underconstruction.png height="20"></img> = Under Construction<br><br/>
+<img src="resources/images/keyboard-1405.png" height="20"> </img> = Software Developers, <img src="resources/images/hatching_chick_newlearner.png" height="35"> </img> = New to Data Science, <img src="resources/images/leaders.png" height = "35"> </img> = Leaders<br></br>
+</div>

--- a/TableKeys.Rmd
+++ b/TableKeys.Rmd
@@ -1,13 +1,15 @@
 ---
-title: "TableKeys"
-author: "Kate Isaac"
-date: "`r Sys.Date()`"
+title: " "
+subtitle: " "
 output: html_document
 ---
 
-```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = TRUE)
-```
+<style type="text/css">
+  body{
+  text-align: justify;
+  text-justify: inter-word;
+}
+</style>
 
 ### **Overview of tables**
 

--- a/TableKeys.Rmd
+++ b/TableKeys.Rmd
@@ -11,18 +11,9 @@ output: html_document
 }
 </style>
 
-### **Overview of tables**
-
-The following tables contains a list of Informatics Technology for Cancer Research (ITCR) program funded courses from the ITCR Training Network (ITN). 
-
-These tables include courses categorized among three broad topics: <b>Best Practices</b> in informatics, <b>Informatic Fundamentals, Tools, and Resources</b>, and <b>Scientific Software Development</b>. A fourth table is included that lists future courses across all three topics.  
-
-Completion through Leanpub (<img src=resources/images/leanpublogo.png height="20"> </img>) or Coursera (<img src=resources/images/courseralogo.png height="20"> </img>) will award certification for a course.
-
-**Table keys:**
 <div title="Table keys">
 <img src="resources/images/ITCRLogo.png" height="20"> </img> = ITCR Funded, <img src=resources/images/fhlogo.png height="20"></img> = Fred Hutch Cancer Center Funded<br></br>
-<img src=resources/images/bookstack.png height="20"> </img> = Bookdown, <img src=resources/images/courseralogo.png height="20"> </img> = Coursera,<img src=resources/images/leanpublogo.png height="20"> </img> = Leanpub, <img src="resources/images/githublogo.png"  height="20"> </img> = GitHub Source Material<br></br>
+<img src=resources/images/bookstack.png height="20"> </img> = Bookdown website, <img src=resources/images/courseralogo.png height="20"> </img> = Coursera,  <img src=resources/images/leanpublogo.png height="20"> </img> = Leanpub,   <img src="resources/images/githublogo.png"  height="20"> </img> = GitHub Source Material<br></br>
 <img src=resources/images/underconstruction.png height="20"></img> = Under Construction<br><br/>
 <img src="resources/images/keyboard-1405.png" height="20"> </img> = Software Developers, <img src="resources/images/hatching_chick_newlearner.png" height="35"> </img> = New to Data Science, <img src="resources/images/leaders.png" height = "35"> </img> = Leaders<br></br>
 </div>

--- a/ToolsResources.Rmd
+++ b/ToolsResources.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Tools & Resources Courses"
+title: " "
 subtitle: " "
 output: html_document
 ---
@@ -11,9 +11,6 @@ output: html_document
 }
 </style>
 
-### **Overview**
-
-The following table contains a list of Informatics Technology for Cancer Research (ITCR) program funded Tools & Resources courses from the ITCR Training Network (ITN). Completion through Leanpub (<img src=resources/images/leanpublogo.png height="20"> </img>) or Coursera (<img src=resources/images/courseralogo.png height="20"> </img>) will award certification in the course.
 
 ```{r,echo=FALSE,results='hide',message=FALSE, warning=FALSE}
 library(DT)
@@ -25,12 +22,6 @@ library(magrittr)
 source("scripts/format-tables.R")
 ```
 
-**Table keys:**
-<div title="Table keys">
-<img src="resources/images/ITCRLogo.png" height="20"> </img> = ITCR Funded, <img src=resources/images/fhlogo.png height="20"></img> = Fred Hutch Cancer Center Funded<br></br>
-<img src=resources/images/bookstack.png height="20"> </img> = Bookdown, <img src=resources/images/courseralogo.png height="20"> </img> = Coursera,<img src=resources/images/leanpublogo.png height="20"> </img> = Leanpub, <img src="resources/images/githublogo.png"  height="20"> </img> = GitHub Source Material<br></br> 
-<img src="resources/images/keyboard-1405.png" height="20"> </img> = Software Developers, <img src="resources/images/hatching_chick_newlearner.png" height="35"> </img> = New to Data Science, <img src="resources/images/leaders.png" height = "35"> </img> = Leaders<br></br>
-</div>
 
 ```{r,echo=FALSE,results='hide',message=FALSE, warning=FALSE}
 # read in the google sheet

--- a/_site.yml
+++ b/_site.yml
@@ -1,10 +1,6 @@
 name: ITN Courses Searchable Table
 output_dir: 'docs'
-navbar:
-  title: ITN Courses Searchable Table
-  left:
-  - text: ""
-    href: index.html
+
 
 output:
   html_document:


### PR DESCRIPTION
This PR 
1. moves the overview and table keys information from each individual `.Rmd` into a new one: `TableKeys.Rmd`. It also removes the titles from those individual `.Rmd` files. 
2. Removes the navbar from `_site.yml`. Perhaps I should have kept the navbar and changed the title to be an empty string and removed the link to `index.html`. I can make that change if you'd prefer

Next
- Need to widen tables
- Potentially add more info about the category of courses in the overview section here 