### PR TITLE
grabbing slides info test

### DIFF
--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -172,7 +172,7 @@ get_slide_info <- function(df){
           try_urlQmd <- try(readlLnes(paste0(base_url, "/main/01-intro.qmd")), silent = TRUE) #try 01-intro.qmd (for Containers course)
           
           if (class(try_urlQmd) != "try-error") {
-            #intro_data <- readLines(paste0(base_url, "/main/01-intro.qmd"))
+            intro_data <- readLines(paste0(base_url, "/main/01-intro.qmd"))
             intro_data <- readLines(make_branch_file_url(base_url, "01-intro.qmd", branch = "kweav-patch-1/"))
           } else {
             intro_data <- ""

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -86,7 +86,7 @@ get_book_info <- function(df){
           extracted_string <- str_extract(coursera_data, url_pattern)
           if (length(extracted_string) > 1){
             df$CourseraLink[i] <- extracted_string[grep("coursera", extracted_string)]
-          } else {df$CourseraLink[i] <- extracted_string}}
+          } else {df$CourseraLink[i] <- extracted_string}
         } else { df$CourseraLink[i] <- NA_character_ }
 
         if(sum(grepl("Leanpub", index_data)) == 1){

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -149,7 +149,7 @@ get_slide_info <- function(df){
   
   if (nrow(df) >=1){
     for (i in 1:nrow(df)) {
-      if (df$book_title != "AI for Decision Makers"){
+      if (df$CourseName != "AI for Decision Makers"){
         # Make raw content url
         base_url <-
           str_replace(df[i,]$html_url,

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -300,7 +300,7 @@ for (page in 1:last) {
     mutate(hutch_funding = str_detect(topics, "hutch-course")) %>%
 
     get_book_info() %>%
-    get_slide_info() %>%
+    get_slide_info()
 
     full_repo_df <- rbind(full_repo_df, repo_df)
 }

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -198,7 +198,7 @@ get_slide_info <- function(df){
         
           if(sum(grepl("topics_covered", intro_data)) >= 1){ #some data not on main yet
             concepts_lines <- grep("topics_covered", intro_data)
-            concepts_data <- str_replace(intro_data[concepts_lines+find_line_of_interest(intro_data, concept_lines)], first_url_replacement, "")
+            concepts_data <- str_replace(intro_data[concepts_lines+find_line_of_interest(intro_data, concepts_lines)], first_url_replacement, "")
             df$concepts_slide[i] <- str_replace(concepts_data, second_url_replacement, "")
           } else {df$concepts_slide[i] <- NA_character_}
         

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -29,7 +29,7 @@ opt <- optparse::parse_args(opt_parser)
 git_pat <- opt$git_pat
 
 #the (?=//)) asserts that there is a parentheses immediately following the URL -- a noncapturing group
-get_linkOI <- function(relevant_data, pattern_to_search, url_pattern = "http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+(?=\\))"){
+get_linkOI <- function(pattern_to_search, relevant_data, url_pattern = "http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+(?=\\))"){
   if(sum(grepl(pattern_to_search, relevant_data)) >= 1){
     relevant_lines <- grep(pattern_to_search, relevant_data)
     data_of_interest <- relevant_data[relevant_lines][grepl("https", relevant_data[relevant_lines])] #select only lines with a URL ... word may be mentioned without a URL
@@ -299,8 +299,8 @@ for (page in 1:last) {
     mutate(hutch_funding = str_detect(topics, "hutch-course")) %>%
     mutate(launch_date = topics) %>%
     tidyr::separate_longer_delim(launch_date, delim = ", ") %>%
-    filter(!str_detect(launch_date, "launchdate-")) %>%
-    mutate(launch_date = str_replace(launch_date, "launchdate-", "")) %>%
+    filter(str_detect(launch_date, "launched-")) %>%
+    mutate(launch_date = str_replace(launch_date, "launched-", "")) %>%
     mutate(launch_date = str_to_title(str_replace(launch_date, pattern = "(.{3})(.*)", replacement = "\\1 \\2"))) %>%
 
     get_book_info() %>%

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -258,9 +258,10 @@ add_rows_with_slides_AIDM <- function(df){
                            lo_slide = c("", "", "", ""),
                            for_slide = c("", "", "", ""),
                            concepts_slide = c("", "", "", ""),
-                           prereq_slide = NA_character_,
-                           name = CourseName
-                            )
+                           prereq_slide = NA_character_
+                          )
+  
+  to_bind_df$name <- to_bind_df$CourseName
     
   #Exploring AI Possibilities: https://raw.githubusercontent.com/fhdsl/AI_for_Decision_Makers/refs/heads/ah/add-slides/01a-AI_Possibilities-intro.Rmd
   branch_file1 <- make_branch_file_url(base_url, "01a-AI_Possibilities-intro.Rmd", branch = "ah/add-slides/")

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -295,7 +295,7 @@ add_rows_with_slides_AIDM <- function(df){
   #Developing AI Policy:
   ## To fill in
     
-  df <- rbind(df, to_bind_df)
+  df <- rbind(df, to_bind_df, fill = TRUE)
   return(df)
 }
 

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -221,10 +221,10 @@ get_slide_info <- function(df){
           df$prereq_slide[i] <- NA_character_
         } else { #NIH for Data Sharing course
           try_urlIndex <- try(readLines(paste0(base_url, "/main/index.Rmd")), silent = TRUE) #try index.Rmd
-          try_urlLO <- try(readlines(paste0(base_url, "/main/LearningObjectives.Rmd")), silent = TRUE) #try LearningObjectives.Rmd
+          try_urlLO <- try(readlines(paste0(base_url, "/main/Learning_objectives.Rmd")), silent = TRUE) #try LearningObjectives.Rmd
           
           if((class(try_urlIndex) != "try-error") & (class(try_urlLO) != "try-error")){
-            intro_data <- c(readLines(paste0(base_url, "/main/index.Rmd")), readlines(paste0(base_url, "/main/LearningObjectives.Rmd")))
+            intro_data <- c(readLines(paste0(base_url, "/main/index.Rmd")), readlines(paste0(base_url, "/main/Learning_objectives.Rmd")))
             df$concepts_slide[i] <- extract_slide_url("topics_covered" , intro_data)
             df$lo_slide[i] <- extract_slide_url("learning_objectives", intro_data)
             df$for_slide[i] <- extract_slide_url("for_individuals_who", intro_data)
@@ -393,7 +393,7 @@ for (page in 1:last) {
     get_slide_info()
     
 
-    full_repo_df <- rbind(full_repo_df, repo_df)
+    full_repo_df <- rbind(full_repo_df, repo_df, fill = TRUE)
 }
 
 full_repo_df <- full_repo_df %>%

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -173,7 +173,6 @@ get_slide_info <- function(df){
           
           if (class(try_urlQmd) != "try-error") {
             intro_data <- readLines(paste0(base_url, "/main/01-intro.qmd"))
-            intro_data <- readLines(make_branch_file_url(base_url, "01-intro.qmd", branch = "kweav-patch-1/"))
           } else {
             intro_data <- ""
             message("No available course information added to this last chunk after checking `01-intro.Rmd` and `01-intro.qmd`")

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -221,10 +221,10 @@ get_slide_info <- function(df){
           df$prereq_slide[i] <- NA_character_
         } else { #NIH for Data Sharing course
           try_urlIndex <- try(readLines(paste0(base_url, "/main/index.Rmd")), silent = TRUE) #try index.Rmd
-          try_urlLO <- try(readlines(paste0(base_url, "/main/Learning_objectives.Rmd")), silent = TRUE) #try LearningObjectives.Rmd
+          try_urlLO <- try(readLines(paste0(base_url, "/main/Learning_objectives.Rmd")), silent = TRUE) #try LearningObjectives.Rmd
           
           if((class(try_urlIndex) != "try-error") & (class(try_urlLO) != "try-error")){
-            intro_data <- c(readLines(paste0(base_url, "/main/index.Rmd")), readlines(paste0(base_url, "/main/Learning_objectives.Rmd")))
+            intro_data <- c(readLines(paste0(base_url, "/main/index.Rmd")), readLines(paste0(base_url, "/main/Learning_objectives.Rmd")))
             df$concepts_slide[i] <- extract_slide_url("topics_covered" , intro_data)
             df$lo_slide[i] <- extract_slide_url("learning_objectives", intro_data)
             df$for_slide[i] <- extract_slide_url("for_individuals_who", intro_data)

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -169,8 +169,7 @@ get_slide_info <- function(df){
         if (class(try_url) != "try-error") {
           intro_data <- readLines(paste0(base_url, "/main/01-intro.Rmd"))
         } else { #if 01-intro.Rmd doesn't exist
-          #try_urlQmd <- try(readlLnes(paste0(base_url, "/main/01-intro.qmd")), silent = TRUE) #try 01-intro.qmd (for Containers course)
-          try_urlQmd <- try(readLines(make_branch_file_url(base_url, "01-intro.qmd", branch = "kweav-patch-1/")), silent = TRUE)
+          try_urlQmd <- try(readlLnes(paste0(base_url, "/main/01-intro.qmd")), silent = TRUE) #try 01-intro.qmd (for Containers course)
           
           if (class(try_urlQmd) != "try-error") {
             #intro_data <- readLines(paste0(base_url, "/main/01-intro.qmd"))

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -297,7 +297,7 @@ add_rows_with_slides_AIDM <- function(df){
   #Developing AI Policy:
   ## To fill in
     
-  df <- rbind(df, to_bind_df, fill = TRUE)
+  df <- dplyr::bind_rows(df, to_bind_df)
   return(df)
 }
 

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -251,14 +251,15 @@ make_branch_file_url <- function(base_url, filename, branch = "/main/"){
 
 add_rows_with_slides_AIDM <- function(df){
   base_url <- make_raw_content_url(df[which(df$CourseName == "AI for Decision Makers"),]$html_url)
-  to_bind_df <- data.frame(CourseName = name = c("AI for Decision Makers: Exploring AI Possibilities",
+  to_bind_df <- data.frame(CourseName = c("AI for Decision Makers: Exploring AI Possibilities",
                                           "AI for Decision Makers: Avoiding AI Harm",
                                           "AI for Decision Makers: Determining AI Needs",
                                           "AI for Decision Makers: Developing AI Policy"),
-                            lo_slide = c("", "", "", ""),
-                            for_slide = c("", "", "", ""),
-                            concepts_slide = c("", "", "", ""),
-                            prereq_slide = NA_character_
+                           lo_slide = c("", "", "", ""),
+                           for_slide = c("", "", "", ""),
+                           concepts_slide = c("", "", "", ""),
+                           prereq_slide = NA_character_,
+                           name = CourseName
                             )
     
   #Exploring AI Possibilities: https://raw.githubusercontent.com/fhdsl/AI_for_Decision_Makers/refs/heads/ah/add-slides/01a-AI_Possibilities-intro.Rmd

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -393,11 +393,11 @@ for (page in 1:last) {
     get_slide_info()
     
 
-    full_repo_df <- rbind(full_repo_df, repo_df, fill = TRUE)
+    full_repo_df <- rbind(full_repo_df, repo_df)
 }
 
 full_repo_df <- full_repo_df %>%
-  add_rows_with_slides_AIDM() %>%
+  #add_rows_with_slides_AIDM() %>%
   tidyr::separate_wider_delim(topics, delim=", ", names_sep = "_", too_few = "align_start") %>%
   mutate(across(starts_with("topics_"), ~replace(., str_detect(., "audience-|category-|course|launched-"), NA))) %>%
   tidyr::unite("Concepts", starts_with("topics_"), sep=';', na.rm = TRUE) %>%

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -390,13 +390,14 @@ for (page in 1:last) {
     mutate(launch_date = str_to_title(str_replace(launch_date, pattern = "(.{3})(.*)", replacement = "\\1 \\2"))) %>%
 
     get_book_info() %>%
-    get_slide_info() %>%
-    add_rows_with_slides_AIDM()
+    get_slide_info()
+    
 
     full_repo_df <- rbind(full_repo_df, repo_df)
 }
 
 full_repo_df <- full_repo_df %>%
+  add_rows_with_slides_AIDM() %>%
   tidyr::separate_wider_delim(topics, delim=", ", names_sep = "_", too_few = "align_start") %>%
   mutate(across(starts_with("topics_"), ~replace(., str_detect(., "audience-|category-|course|launched-"), NA))) %>%
   tidyr::unite("Concepts", starts_with("topics_"), sep=';', na.rm = TRUE) %>%

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -188,18 +188,24 @@ get_slide_info <- function(df){
           first_url_replacement <- 'ottrpal::include_slide\\(\"'
           second_url_replacement <- '\"\\)'
         
-          concepts_lines <- grep("topics_covered", intro_data)
-          concepts_data <- str_replace(intro_data[concepts_lines+1], first_url_replacement, "")
-          df$concepts_slide[i] <- str_replace(concepts_data, second_url_replacement, "")
+          if(sum(grepl("topics_covered", intro_data)) >= 1){
+            concepts_lines <- grep("topics_covered", intro_data)
+            concepts_data <- str_replace(intro_data[concepts_lines+1], first_url_replacement, "")
+            df$concepts_slide[i] <- str_replace(concepts_data, second_url_replacement, "")
+          }
         
-          lo_lines <- grep("learning_objectives", intro_data)
-          lo_data <- str_replace(intro_data[lo_lines+1], first_url_replacement, "")
-          df$lo_slide[i] <- str_replace(lo_data, second_url_replacement, "")
+          if(sum(grepl("learning_objectives", intro_data)) >= 1){
+            lo_lines <- grep("learning_objectives", intro_data)
+            lo_data <- str_replace(intro_data[lo_lines+1], first_url_replacement, "")
+            df$lo_slide[i] <- str_replace(lo_data, second_url_replacement, "")
+          }
         
-          for_lines <- grep("for_individuals_who", intro_data)
-          for_data <- str_replace(intro_data[for_lines+1], first_url_replacement, "")
-          df$for_slide[i] <- str_replace(for_data, second_url_replacement, "")
-        
+          if(sum(grepl("for_individuals_who", intro_data)) >=1){
+            for_lines <- grep("for_individuals_who", intro_data)
+            for_data <- str_replace(intro_data[for_lines+1], first_url_replacement, "")
+            df$for_slide[i] <- str_replace(for_data, second_url_replacement, "")
+          }
+          
           if(sum(grepl("prereqs", intro_data)) >= 1){
             prereq_lines <- grep("prereqs", intro_data)
             prereq_data <- str_replace(intro_data[prereq_lines+1], first_url_replacement, "")

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -248,6 +248,7 @@ make_branch_file_url <- function(base_url, filename, branch = "/main/"){
 }
 
 add_rows_with_slides_AIDM <- function(df){
+  base_url <- make_raw_content_url(df[which(df$CourseName == "AI for Decision Makers"),]$html_url)
   to_bind_df <- data.frame(CourseName = c("AI for Decision Makers: Exploring AI Possibilities",
                                           "AI for Decision Makers: Avoiding AI Harm",
                                           "AI for Decision Makers: Determining AI Needs",

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -399,7 +399,7 @@ for (page in 1:last) {
 }
 
 full_repo_df <- full_repo_df %>%
-  #add_rows_with_slides_AIDM() %>%
+  add_rows_with_slides_AIDM() %>%
   tidyr::separate_wider_delim(topics, delim=", ", names_sep = "_", too_few = "align_start") %>%
   mutate(across(starts_with("topics_"), ~replace(., str_detect(., "audience-|category-|course|launched-"), NA))) %>%
   tidyr::unite("Concepts", starts_with("topics_"), sep=';', na.rm = TRUE) %>%

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -169,10 +169,12 @@ get_slide_info <- function(df){
         if (class(try_url) != "try-error") {
           intro_data <- readLines(paste0(base_url, "/main/01-intro.Rmd"))
         } else { #if 01-intro.Rmd doesn't exist
-          try_urlQmd <- try(readlines(paste0(base_url, "/main/01-intro.qmd")), silent = TRUE) #try 01-intro.qmd (for Containers course)
-            
+          #try_urlQmd <- try(readlLnes(paste0(base_url, "/main/01-intro.qmd")), silent = TRUE) #try 01-intro.qmd (for Containers course)
+          try_urlQmd <- try(readLines(make_branch_file_url(base_url, "01-intro.qmd", branch = "kweav-patch-1/")), silent = TRUE)
+          
           if (class(try_urlQmd) != "try-error") {
-            intro_data <- readlines(paste0(base_url, "/main/01-intro.qmd"))
+            #intro_data <- readLines(paste0(base_url, "/main/01-intro.qmd"))
+            intro_data <- readLines(make_branch_file_url(base_url, "01-intro.qmd", branch = "kweav-patch-1/"))
           } else {
             intro_data <- ""
             message("No available course information added to this last chunk after checking `01-intro.Rmd` and `01-intro.qmd`")
@@ -261,10 +263,10 @@ add_rows_with_slides_AIDM <- function(df){
     
   #Exploring AI Possibilities: https://raw.githubusercontent.com/fhdsl/AI_for_Decision_Makers/refs/heads/ah/add-slides/01a-AI_Possibilities-intro.Rmd
   branch_file1 <- make_branch_file_url(base_url, "01a-AI_Possibilities-intro.Rmd", branch = "ah/add-slides/")
-  try_AI_url1 <- try(readlines(branch_file1), silent = TRUE)
+  try_AI_url1 <- try(readLines(branch_file1), silent = TRUE)
     
   if(class(try_AI_url1) != "try-error") {
-    intro_data <- readlines(branch_file1)
+    intro_data <- readLines(branch_file1)
     to_bind_df[1,]$lo_slide <- extract_slide_url("learning_objectives", intro_data)
     to_bind_df[1,]$for_slide <- extract_slide_url("for_individuals_who", intro_data)
     to_bind_df[1,]$concepts_slide <- extract_slide_url("topics_covered", intro_data)
@@ -276,10 +278,10 @@ add_rows_with_slides_AIDM <- function(df){
     
   #Avoiding AI Harm: https://raw.githubusercontent.com/fhdsl/AI_for_Decision_Makers/refs/heads/cw_add_slides/02a-Avoiding_Harm-intro.Rmd
   branch_file2 <- make_branch_file_url(base_url, "02a-Avoiding_Harm-intro.Rmd", branch = "cw_add_slides/")
-  try_AI_url2 <- try(readlines(branch_file2), silent = TRUE)
+  try_AI_url2 <- try(readLines(branch_file2), silent = TRUE)
   
   if(class(try_AI_url2) != "try-error") {
-    intro_data <- readlines(branch_file2)
+    intro_data <- readLines(branch_file2)
     to_bind_df[2,]$lo_slide <- extract_slide_url("learning_objectives", intro_data)
     to_bind_df[2,]$for_slide <- extract_slide_url("for_individuals_who", intro_data)
     to_bind_df[2,]$concepts_slide <- extract_slide_url("topics_covered", intro_data)

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -149,7 +149,7 @@ get_slide_info <- function(df){
   
   if (nrow(df) >=1){
     for (i in 1:nrow(df)) {
-      if (df$CourseName != "AI for Decision Makers"){
+      if (df$CourseName[i] != "AI for Decision Makers"){
         # Make raw content url
         base_url <-
           str_replace(df[i,]$html_url,

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -66,9 +66,10 @@ get_book_info <- function(df){
 
         # Append
         df$CourseName[i] <- CourseName
+        
+        print(CourseName)
 
         # Get Available Course Format Links
-        ## NIH has everything on the same line, soooooo need to handle that -- can I do a specific grep on str_extract? Imagine it's grabbing every URL, right??!
         url_pattern <- "http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+(?=\\))" #the (?=//)) asserts that there is a parentheses immediately following the URL -- a noncapturing group
         
         if(sum(grepl("Coursera", index_data)) >= 1){

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -205,6 +205,7 @@ get_slide_info <- function(df){
             prereq_data <- str_replace(intro_data[prereq_lines+1], first_url_replacement, "")
             df$prereq_slide[i] <- str_replace(prereq_data, second_url_replacement, "")
           }
+        }
       } else { message("This will be filled in later with branch specific grabbing of slides.")} #check AI for Decision Makers branches 
     }#end for loop
   } else { message("No relevant resources, so no data added")} #end if not at least one row

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -150,10 +150,7 @@ get_book_info <- function(df){
 }
 
 
-find_line_of_interest <- function(char_vec, line_with_tag){
-  first_url_replacement <- 'ottrpal::include_slide\\(\"'
-  second_url_replacement <- '\"\\)'
-
+find_line_of_interest <- function(char_vec, line_with_tag, first_url_replacement = 'ottrpal::include_slide\\(\"', second_url_replacement = '\"\\)'){
   data_of_interest <- char_vec[(line_with_tag+1):(line_with_tag+2)]
   str_replace_doi <- str_replace(data_of_interest, first_url_replacement, "")
   str_replace_doi <- str_replace(str_replace_doi, second_url_replacement, "")
@@ -163,6 +160,10 @@ find_line_of_interest <- function(char_vec, line_with_tag){
 # -------- Function to get slide URL info ----------
 
 get_slide_info <- function(df){
+  
+  first_url_replacement <- 'ottrpal::include_slide\\(\"'
+  second_url_replacement <- '\"\\)'
+  
   df$concepts_slide <- ""
   df$lo_slide <- ""
   df$for_slide <- ""

--- a/scripts/query_collection.R
+++ b/scripts/query_collection.R
@@ -251,7 +251,7 @@ make_branch_file_url <- function(base_url, filename, branch = "/main/"){
 
 add_rows_with_slides_AIDM <- function(df){
   base_url <- make_raw_content_url(df[which(df$CourseName == "AI for Decision Makers"),]$html_url)
-  to_bind_df <- data.frame(CourseName = c("AI for Decision Makers: Exploring AI Possibilities",
+  to_bind_df <- data.frame(CourseName = name = c("AI for Decision Makers: Exploring AI Possibilities",
                                           "AI for Decision Makers: Avoiding AI Harm",
                                           "AI for Decision Makers: Determining AI Needs",
                                           "AI for Decision Makers: Developing AI Policy"),
@@ -399,10 +399,10 @@ for (page in 1:last) {
 }
 
 full_repo_df <- full_repo_df %>%
-  add_rows_with_slides_AIDM() %>%
   tidyr::separate_wider_delim(topics, delim=", ", names_sep = "_", too_few = "align_start") %>%
   mutate(across(starts_with("topics_"), ~replace(., str_detect(., "audience-|category-|course|launched-"), NA))) %>%
   tidyr::unite("Concepts", starts_with("topics_"), sep=';', na.rm = TRUE) %>%
+  add_rows_with_slides_AIDM() %>%
   rename(GithubLink = html_url) %>%
   rename(BookdownLink = homepage) #already available from the API calls, so don't need to extract it
 

--- a/testProgrammatic.Rmd
+++ b/testProgrammatic.Rmd
@@ -23,7 +23,7 @@ source("scripts/format-tables.R")
 ```{r}
 full_repo_df <- read_tsv(here("resources/collection.tsv"))
 full_repo_df$CurrentOrFuture = "Current"
-full_repo_df <- full_repo_df %>% filter(grepl(CourseName, ":"))
+full_repo_df <- full_repo_df %>% filter(!grepl(":", CourseName))
 ```
 ```{r}
 wrangled <- full_repo_df %>%

--- a/testProgrammatic.Rmd
+++ b/testProgrammatic.Rmd
@@ -25,6 +25,25 @@ full_repo_df <- read_tsv(here("resources/collection.tsv"))
 full_repo_df$CurrentOrFuture = "Current"
 
 ```
+```{r}
+colnames(full_repo_df)
+```
+
+```{r}
+sum(is.na(full_repo_df$concepts_slide))
+```
+
+```{r}
+sum(is.na(full_repo_df$lo_slide))
+```
+
+```{r}
+sum(is.na(full_repo_df$for_slide))
+```
+
+```{r}
+sum(is.na(full_repo_df$prereq_slide))
+```
 
 ```{r}
 wrangled <- full_repo_df %>%

--- a/testProgrammatic.Rmd
+++ b/testProgrammatic.Rmd
@@ -46,6 +46,10 @@ sum(is.na(full_repo_df$prereq_slide))
 ```
 
 ```{r}
+saveRDS(full_repo_df, file = here("resources/testCollection.rds"))
+```
+
+```{r}
 wrangled <- full_repo_df %>%
   mutate(Concepts = str_to_title(Concepts),
          Concepts = str_replace_all(Concepts, "Ai", "AI"),

--- a/testProgrammatic.Rmd
+++ b/testProgrammatic.Rmd
@@ -23,32 +23,8 @@ source("scripts/format-tables.R")
 ```{r}
 full_repo_df <- read_tsv(here("resources/collection.tsv"))
 full_repo_df$CurrentOrFuture = "Current"
-
+full_repo_df <- full_repo_df %>% filter(grepl(CourseName, ":"))
 ```
-```{r}
-colnames(full_repo_df)
-```
-
-```{r}
-sum(is.na(full_repo_df$concepts_slide))
-```
-
-```{r}
-sum(is.na(full_repo_df$lo_slide))
-```
-
-```{r}
-sum(is.na(full_repo_df$for_slide))
-```
-
-```{r}
-sum(is.na(full_repo_df$prereq_slide))
-```
-
-```{r}
-saveRDS(full_repo_df, file = here("resources/testCollection.rds"))
-```
-
 ```{r}
 wrangled <- full_repo_df %>%
   mutate(Concepts = str_to_title(Concepts),


### PR DESCRIPTION
This adds a few functions to make the code a bit DRYer:
- `make_raw_content_url()`: Given the github link for an ITN course, use a str_replace to return a "base_url" that will be used whenever grabbing a raw version of a specific repo file for that course
- `get_linkOI()`: When extracting available course format links, this function accepts a pattern to search (e.g., "Coursera", "Leanpub"), the relevant data to search (e.g., a character vector from readLines), and has a named argument for the url_pattern that str_extract uses to extract the relevant URL. Note that this function now uses str_extract_all rather than str_extract since NIH for Data Sharing has all the relevant links on the same line instead of in a bulleted list- and this function now handles both of those usescases
- `find_line_of_interest()`: When grabbing the ottrpal::include_slide URLs for slides for audience, LOs, etc., I noticed that not all courses automatically go from the first line of the chunk (e.g., ```r learning_objectives, ....) to `ottrpal::include_slide("http...`. Some have a line in between. So my original approach of adding 1 to the result of grep (the line with tag of interest) didn't work -- this function now checks both the next and the second next line and returns a 1 or a 2 for whichever one has the expected "http" from a URL. (lines 135 and 136 may not be necessary there? I haven't tried removing them yet but would strongly guess they're not necessary)
- `extract_slide_url()`:  Given that we know the line of the tag of interest (start of the code chunk with the slide URL we want), we find the line in that code chunk that has the URL and extract the URL using str_replace(). 
- `get_slide_info()`: paralel to the `get_book_info()` function that we added last time -- but focusing on grabbing slide info for audience, LOs, etc for courses rather than book title and available course formats.
- `make_branch_file_url()`: given a base_url, a filename, and a branch, build the URL to read the raw version of a file on a branch (probably not main)
- `add_rows_with_slides_AIDM()`: Made AI for Decision Makers its own function to grab slide info since each subcourse has individual slides and the course only has one row in the overall table. This function adds a new row for each subcourse (with just names and slide URLs) to the overall table.

Note we no longer extract `BookdownLink`, because I realized that was already provided by the GitHub API as `homepage`. 

And Launch dates are extracted from the topic tags and added as their own column. 

Finally we remove the 4 new subcourse rows from the full dataframe before making the course table

This PR handles the following two "next steps" from the previous PR
- [X] verifying automatic retrieval is working (still)
- [X] grabbing the slide links for concepts covered, learning objectives, for people who, and prereq (if applicable) slides within query_collection.R
 
 while still leaving these two "next steps" from the previous PR for future work
 - [ ] generating the page (for each course)
 - [ ] linking the page in the table to at least the course name (potentially the whole row?)