### PR TITLE
Update README.md with documentation for adding a course

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,25 @@ The table only includes repositories that meet the following criteria:
 - Have "itn" and "course" as part of the tags (e.g., "itn-course", or "itn" and "course") (`str_detect(topics, "itn")` & `str_detect(topics, "course")`)
 - Aren't template per the tags (`!str_detect(topics, "template ")` -- using a space because we want repos with tags of "templates" if the repo is providing templates)
 
+### Interested in adding a course to the table?
+
+- Make sure the above required criteria are met (public, homepage, description, itn-course tag, isn't a template)
+- Verify that the title is in the index.Rmd (or _quarto.yml for quarto book) file, following the convention of being listed between `---` with `title:` at the front of the line with the title
+- Verify that available course formats are listed in index.Rmd (or index.qmd for quarto book) file, specifically for Coursera and Leanpub if applicable
+- Verify that the `01-intro.Rmd` file has identifiers for code blocks grabbing relevant google slide images. If it's not that file, you'll need to edit the `get_slide_info()` function within the `query_collection.R` file.
+  - LOs: `learning_objectives`
+  - Audience: `for_individuals_who`
+  - Topics covered: `topics_covered`
+  - Pre-reqs (if applicable): `prereqs`
+- Add repo tags for audience (at least one of the following):
+  - `audience-software-developers`
+  - `audience-researchers`
+  - `audience-leaders`
+- Add repo tags for category (only one of the following):
+  - `category-best-practices`
+  - `category-software-dev`
+  - `category-fundamentals-tools-resources`
+
 ## Important files
 
 - `scripts/query_collection.R`: gathers information (audience, funding, topics, etc.) about ITN courses from their GitHub repos

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ The table only includes repositories that meet the following criteria:
 - Have a description listed
 - Have "itn" and "course" as part of the tags (e.g., "itn-course", or "itn" and "course") (`str_detect(topics, "itn")` & `str_detect(topics, "course")`)
 - Aren't template per the tags (`!str_detect(topics, "template ")` -- using a space because we want repos with tags of "templates" if the repo is providing templates)
+- Has a tag for launch date specified by `launched-monYEAR` (e.g., `launched-aug2025` or `launched-dec2023`)
 
 ### Interested in adding a course to the table?
 
-- Make sure the above required criteria are met (public, homepage, description, itn-course tag, isn't a template)
+- Make sure the above required criteria are met (public, homepage, description, itn-course tag, isn't a template, launch date tag)
 - Verify that the title is in the index.Rmd (or _quarto.yml for quarto book) file, following the convention of being listed between `---` with `title:` at the front of the line with the title
 - Verify that available course formats are listed in index.Rmd (or index.qmd for quarto book) file, specifically for Coursera and Leanpub if applicable
 - Verify that the `01-intro.Rmd` file has identifiers for code blocks grabbing relevant google slide images. If it's not that file, you'll need to edit the `get_slide_info()` function within the `query_collection.R` file.

--- a/index.Rmd
+++ b/index.Rmd
@@ -47,7 +47,10 @@ wrangled <- full_repo_df %>%
          Concepts = str_replace_all(Concepts, "Pii", "(PII)"),
          Concepts = str_replace_all(Concepts, "Arxiv", "ArXiv"),
          Concepts = str_replace_all(Concepts, "Latex", "LaTex"),
-         Concepts = str_replace_all(Concepts, "And", "&")
+         Concepts = str_replace_all(Concepts, "And", "&"),
+         Concepts = str_replace_all(Concepts, "Iv", "IV"),
+         Concepts = str_replace_all(Concepts, "Iii", "III"),
+         Concepts = str_replace_all(Concepts, "Ii", "II")
         )
 ```
 

--- a/scripts/format-tables.R
+++ b/scripts/format-tables.R
@@ -57,7 +57,7 @@ prep_table <- function(inputdf, current=TRUE, keep_category = FALSE){
     ) %>% #Make the concepts bulletted instead of separated by semi-colons
     mutate(Concepts = paste0("• ", Concepts)) %>%
     mutate(Concepts = str_replace_all(Concepts, ";", "<br>• ")) %>% #add a line break and the next bullet
-    mutate(Concepts = str_replace_all(Concepts, "-", " ")) %>% #replace the hyphens/dashes with a space; special cases are taken care of before rendering
+    mutate(Concepts = str_replace_all(Concepts, "-", " ")) %>% #replace the hyphens/dashes with a space; special cases/substitutions are taken care of before rendering within index.Rmd
     mutate(BroadAudience = str_replace_all(BroadAudience, ";", "<br></br>")) %>%
     #Replace the broad audiences with logos
     mutate(BroadAudience = str_replace(BroadAudience, "Software Developers", "<img src=\"resources/images/SoftwareDeveloper.png\" alt=\"Software Developers\" height=\"40\"></img><p class=\"image-name\">Software Developers</p>")) %>%


### PR DESCRIPTION
Currently adding documentation about any new course's repo and the files and what we want to be true for the course table to grab the info and display it how we want it

Should probably add some guidance about rerunning actions (which ones) to re-render the table after you've verified all of this information is correct. But how is it looking so far? @carriewright11 