### PR TITLE
add prereq condition for capstone course

### DIFF
--- a/chunks/prereqsCourse.Rmd
+++ b/chunks/prereqsCourse.Rmd
@@ -34,7 +34,7 @@ if (str_detect({GITHUB_LINK}, pattern = "Automation|Containers")){cat('<div clas
 }
 
 # if the capstone course, paste link in a span with larger font in html to intro, advanced, actions, and containers courses
-if (str_detec({GITHUB_LINK}, pattern = "capstone")){
+if (str_detect({GITHUB_LINK}, pattern = "capstone")){
   cat('<div class = blackbox>Please check out our [Introduction to Reproducibility Course](https://jhudatascience.org/Reproducibility_in_Cancer_Informatics), our [Advanced Reproducibility Course](https://jhudatascience.org/Adv_Reproducibility_in_Cancer_Informatics), our [GitHub Automation for Scientists Course](https://hutchdatascience.org/GitHub_Automation_for_Scientists/), and our [Containers for Scientists Course](https://hutchdatascience.org/Containers_for_Scientists/).</div>')
 }
 


### PR DESCRIPTION
Add in a condition so that if the course that's using the pre-reqs chunk is the capstone course, it'll link to all four of the rest of the reproducibility courses. 

Addressing Issue #24 